### PR TITLE
Double Brace Interpolation

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -5,16 +5,18 @@ const l10n = {
   "foo": "bar",
   "hotel": "trivago",
   "alpha": "there's a simple item",
-  "beta": "there's a {item} with replacement",
-  "gamma": "there's a letter for {receiver}, from {sender}",
-  "delta": "I have a counter marking {n}",
-  "epsilon": "you could stop and five or six stores, or, just {n}",
-  "epsilon_zero": "This here > \"{n}\" < should not be empty",
-  "epsilon_plural": "Gee Bill! How come your mom lets you eat {n} weiners?",
+  "beta": "there's a {{item}} with replacement",
+  "gamma": "there's a letter for {{receiver}}, from {{sender}}",
+  "delta": "I have a counter marking {{n}}",
+  "epsilon": "you could stop and five or six stores, or, just {{n}}",
+  "epsilon_zero": "This here > \"{{n}}\" < should not be empty",
+  "epsilon_plural": "Gee Bill! How come your mom lets you eat {{n}} weiners?",
   "nested": {
     "values": "am I right?",
-    "replacements": "Datawheel's biggest projects are {first}, {second}, and {third}."
-  }
+    "replacements": "Datawheel's biggest projects are {{first}}, {{second}}, and {{third}}."
+  },
+  "single": "Hello {name}",
+  "double": "Hello {{name}}"
 };
 
 const t = translateFunctionFactory(l10n);
@@ -52,7 +54,7 @@ describe("translateFunctionFactory", () => {
   });
 
   it("should return the same key if term is not in translation dict, and perform a replacement", () => {
-    assert.strictEqual(t("a variable {foo} used for examples", {foo: "bar"}), "a variable bar used for examples");
+    assert.strictEqual(t("a variable {{foo}} used for examples", {foo: "bar"}), "a variable bar used for examples");
   });
 
   it("should return a term using a nested key from translation dict", () => {
@@ -62,4 +64,9 @@ describe("translateFunctionFactory", () => {
   it("should return a term using a nested key from translation dict, and perform a value replacement", () => {
     assert.strictEqual(t("nested.replacements", {first: "the OEC", second: "DataUSA", third: "DataMexico"}), "Datawheel's biggest projects are the OEC, DataUSA, and DataMexico.");
   });
+
+  it("should replace a single and double braced variable in the same way", () => {
+    const vars = {name: "Tester"};
+    assert.strictEqual(t("single", vars), t("double", vars));
+  })
 });

--- a/index.ts
+++ b/index.ts
@@ -199,7 +199,7 @@ export function translateFunctionFactory(dictionary: TranslationDict): Translate
     return path.value;
   };
   
-  const braceRegex = /{(\d+|[a-z$_][a-z\d$_]*?(?:\.[a-z\d$_]*?)*?)}/gi;
+  cosnt braceRegex = /{{1,2}(\d+|[a-z$_][a-z\d$_]*?(?:\.[a-z\d$_]*?)*?)}{1,2}/gi
 
   return (template, data) => {
     const path = getPathInfo(dictionary, template);

--- a/index.ts
+++ b/index.ts
@@ -199,7 +199,7 @@ export function translateFunctionFactory(dictionary: TranslationDict): Translate
     return path.value;
   };
   
-  cosnt braceRegex = /{{1,2}(\d+|[a-z$_][a-z\d$_]*?(?:\.[a-z\d$_]*?)*?)}{1,2}/gi
+  const braceRegex = /{{1,2}(\d+|[a-z$_][a-z\d$_]*?(?:\.[a-z\d$_]*?)*?)}{1,2}/gi
 
   return (template, data) => {
     const path = getPathInfo(dictionary, template);


### PR DESCRIPTION
Add compatibility for interpolation with double-braced variables as well as single braced templates. Currently, only single braces are supported, but this does not conform to i18n standards.

E.g. `"Hello {name}"` and `"Hello {{name}}"` would both be acceptable now.